### PR TITLE
Implement iso2108 method #1

### DIFF
--- a/src/main/java/de/creativecouple/validation/isbn/ISBN.java
+++ b/src/main/java/de/creativecouple/validation/isbn/ISBN.java
@@ -52,6 +52,11 @@ public final class ISBN implements Serializable, Comparable<ISBN> {
      */
     private final Hyphenation hyphenation;
 
+    /**
+     * lazy-loaded hyphenated representation of this ISBN
+     */
+    private String hyphenated;
+
     ISBN(String isbn, Hyphenation hyphenation) {
         this.isbn = isbn;
         this.hyphenation = hyphenation;
@@ -194,7 +199,19 @@ public final class ISBN implements Serializable, Comparable<ISBN> {
      */
     @Override
     public String toString() {
-        return getPrefix() + '-' + getGroup() + '-' + getPublisher() + '-' + getTitle() + '-' + getCheckdigit();
+        if (hyphenated == null) {
+            hyphenated = getPrefix() + '-' + getGroup() + '-' + getPublisher() + '-' + getTitle() + '-' + getCheckdigit();
+        }
+        return hyphenated;
+    }
+
+    /**
+     * Returns the human-readable ISO-2108 standard representation of this ISBN.
+     *
+     * @return the official human-readable ISO-2108 standard representation, e.g. "ISBN 978-0-557-50469-5"
+     */
+    public String iso2108() {
+        return "ISBN " + this;
     }
 
     /**

--- a/src/main/java/de/creativecouple/validation/isbn/ISBN.java
+++ b/src/main/java/de/creativecouple/validation/isbn/ISBN.java
@@ -208,9 +208,10 @@ public final class ISBN implements Serializable, Comparable<ISBN> {
     /**
      * Returns the human-readable ISO-2108 standard representation of this ISBN.
      *
+     * @since 1.1.2
      * @return the official human-readable ISO-2108 standard representation, e.g. "ISBN 978-0-557-50469-5"
      */
-    public String iso2108() {
+    public String toIso2108() {
         return "ISBN " + this;
     }
 

--- a/src/test/java/de/creativecouple/validation/isbn/ISBNTest.java
+++ b/src/test/java/de/creativecouple/validation/isbn/ISBNTest.java
@@ -36,6 +36,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("9-780-6-3-9-96-35-4-9");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-0-6399635-4-9");
+        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
         assertThat(isbn.toCompactString()).isEqualTo("9780639963549");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9780639963549"));
         assertThat(isbn.getPrefix()).isEqualTo("978");
@@ -54,6 +55,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("9_780-6\u20133\u20149_9_63-5-4\u22129");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-0-6399635-4-9");
+        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
         assertThat(isbn.toCompactString()).isEqualTo("9780639963549");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9780639963549"));
         assertThat(isbn.getPrefix()).isEqualTo("978");
@@ -72,6 +74,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("979-8421221814");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("979-8-4212-2181-4");
+        assertThat(isbn.iso2108()).isEqualTo("ISBN 979-8-4212-2181-4");
         assertThat(isbn.toCompactString()).isEqualTo("9798421221814");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9798421221814"));
         assertThat(isbn.getPrefix()).isEqualTo("979");
@@ -90,6 +93,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("394718834-X");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-3-947188-34-5");
+        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-3-947188-34-5");
         assertThat(isbn.toCompactString()).isEqualTo("9783947188345");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9783947188345"));
         assertThat(isbn.getPrefix()).isEqualTo("978");

--- a/src/test/java/de/creativecouple/validation/isbn/ISBNTest.java
+++ b/src/test/java/de/creativecouple/validation/isbn/ISBNTest.java
@@ -36,7 +36,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("9-780-6-3-9-96-35-4-9");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-0-6399635-4-9");
-        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
+        assertThat(isbn.toIso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
         assertThat(isbn.toCompactString()).isEqualTo("9780639963549");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9780639963549"));
         assertThat(isbn.getPrefix()).isEqualTo("978");
@@ -55,7 +55,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("9_780-6\u20133\u20149_9_63-5-4\u22129");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-0-6399635-4-9");
-        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
+        assertThat(isbn.toIso2108()).isEqualTo("ISBN 978-0-6399635-4-9");
         assertThat(isbn.toCompactString()).isEqualTo("9780639963549");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9780639963549"));
         assertThat(isbn.getPrefix()).isEqualTo("978");
@@ -74,7 +74,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("979-8421221814");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("979-8-4212-2181-4");
-        assertThat(isbn.iso2108()).isEqualTo("ISBN 979-8-4212-2181-4");
+        assertThat(isbn.toIso2108()).isEqualTo("ISBN 979-8-4212-2181-4");
         assertThat(isbn.toCompactString()).isEqualTo("9798421221814");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9798421221814"));
         assertThat(isbn.getPrefix()).isEqualTo("979");
@@ -93,7 +93,7 @@ class ISBNTest {
         ISBN isbn = ISBN.valueOf("394718834-X");
         assertThat(isbn).isNotNull();
         assertThat(isbn.toString()).isEqualTo("978-3-947188-34-5");
-        assertThat(isbn.iso2108()).isEqualTo("ISBN 978-3-947188-34-5");
+        assertThat(isbn.toIso2108()).isEqualTo("ISBN 978-3-947188-34-5");
         assertThat(isbn.toCompactString()).isEqualTo("9783947188345");
         assertThat(isbn.toURI()).isEqualTo(URI.create("urn:isbn:9783947188345"));
         assertThat(isbn.getPrefix()).isEqualTo("978");


### PR DESCRIPTION
Fulfil #1 by adding `ISBN.toIso2108()`

also improved performance of consecutive `.toString()` calls