### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/auto-merge-isbn-updates.yaml
+++ b/.github/workflows/auto-merge-isbn-updates.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -20,10 +20,10 @@ jobs:
           git config --global user.name "Jenkins"
           git rebase $GITHUB_SHA
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/release-monthly.yaml
+++ b/.github/workflows/release-monthly.yaml
@@ -13,7 +13,7 @@ jobs:
       changes_found: ''
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -24,11 +24,11 @@ jobs:
           git config --global user.name "Jenkins"
           echo "changes_found=$(git diff --name-only release-latest..main src/main | head -n 1)" >> $GITHUB_ENV
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         if: env.changes_found != ''
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME


### PR DESCRIPTION
- replace `actions/setup-java@v4` with `actions/setup-java@v5`
- replace `actions/checkout@v4` with `actions/checkout@v7`
- use Java 25 instead of 17

fixes #13 